### PR TITLE
Refer to HTML specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "is-interactive-element",
   "version": "2.0.1",
-  "description": "Checks if an element is an interactive element according to the WHATWG spec",
+  "description": "Checks if an element is an interactive element according to the HTML specification",
   "main": "dist/index.js",
   "devDependencies": {
     "@types/jest": "^25.1.2",


### PR DESCRIPTION
This makes the description more precise and leaves out the organisation that maintains the specification as there is currently only one such organisation.